### PR TITLE
Fix Dependabot #114: force uuid >=14.0.0 to remediate missing buffer bounds check CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@tootallnate/once": ">=3.0.1"
+      "@tootallnate/once": ">=3.0.1",
+      "uuid": ">=14.0.0"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@tootallnate/once': '>=3.0.1'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -4416,8 +4417,8 @@ packages:
   utila@0.4.0:
     resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5851,7 +5852,7 @@ snapshots:
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 8.6.18(prettier@3.8.3)
-      uuid: 9.0.1
+      uuid: 14.0.0
 
   '@storybook/addon-backgrounds@8.6.14(storybook@8.6.18(prettier@3.8.3))':
     dependencies:
@@ -9657,7 +9658,7 @@ snapshots:
 
   utila@0.4.0: {}
 
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `uuid: >=14.0.0` to `pnpm.overrides` to force resolution of the transitive `uuid` dependency introduced via `@storybook/addon-essentials`
- Remediates Dependabot alert #114: missing buffer bounds check in `uuid` v3/v5/v6 when a caller-provided buffer is used (silent partial writes without `RangeError`)
- `uuid` is a devDependency only — no impact on the published package or end users

## Test plan

- [x] `pnpm install` — `+1 -1` confirms uuid was upgraded
- [x] `pnpm audit` — No known vulnerabilities found
- [x] `pnpm test:ci` — 12 suites, 24 tests, 19 snapshots all pass
- [x] `pnpm build-storybook` — clean build, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)